### PR TITLE
Display product and collection ids in badges

### DIFF
--- a/hipposerve/web/templates/collection.html
+++ b/hipposerve/web/templates/collection.html
@@ -2,6 +2,7 @@
 {% block content %}
 <div class="container-fluid fs-base">
 <h2>{{ collection.name }}</h2>
+<span class="badge text-bg-secondary mb-1 p-2">ID: {{ collection.id }}</span>
 {% markdown %}
 {{ collection.description }}
 {% endmarkdown %}

--- a/hipposerve/web/templates/product.html
+++ b/hipposerve/web/templates/product.html
@@ -2,9 +2,10 @@
 {% block content %}
 <div class="container-fluid">
     <h1>{{ product.name }}</h1>
-    <span class="badge text-bg-secondary">Uploaded: {{ product.uploaded.strftime('%Y-%m-%d %H:%M:%S') }}</span>
-    <span class="badge text-bg-secondary">Modified: {{ product.updated.strftime('%Y-%m-%d %H:%M:%S') }}</span>
-    <span class="badge text-bg-secondary">Owner: {{ product.owner.name }}</span>
+    <span class="badge text-bg-secondary p-2">ID: {{ product.id }}</span>
+    <span class="badge text-bg-secondary p-2">Uploaded: {{ product.uploaded.strftime('%Y-%m-%d %H:%M:%S') }}</span>
+    <span class="badge text-bg-secondary p-2">Modified: {{ product.updated.strftime('%Y-%m-%d %H:%M:%S') }}</span>
+    <span class="badge text-bg-secondary p-2">Owner: {{ product.owner.name }}</span>
 
     <h2 class="mt-3">Product Description</h2>
     {% markdown %}


### PR DESCRIPTION
In addition to displaying the ids in both product and collection pages, I increased the padding of the badges to make them slightly more prominent.

![image](https://github.com/user-attachments/assets/cb40504f-e17a-499e-a6d0-9149f44fe26d)
![image](https://github.com/user-attachments/assets/d28cb29b-860d-4436-b615-67bddc3a155e)
