### PR TITLE
Initial authentication implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 build/*
 
 env*
+.env*
 
 examples/*.fits
 

--- a/examples/aiola/simple_crud_coadd.py
+++ b/examples/aiola/simple_crud_coadd.py
@@ -6,7 +6,7 @@
 #
 # In this script, we:
 # 1. Read a collection.
-# 2. Filter the products in the collection to findg the ones we want
+# 2. Filter the products in the collection to find the ones we want
 #    (in this case, the splits in a particular patch).
 # 3. Read the data from the products.
 # 4. Create a co-added map from the splits.

--- a/examples/aiola/simple_crud_coadd.py
+++ b/examples/aiola/simple_crud_coadd.py
@@ -6,7 +6,7 @@
 #
 # In this script, we:
 # 1. Read a collection.
-# 2. Filter the products in the collection to find the ones we want
+# 2. Filter the products in the collection to findg the ones we want
 #    (in this case, the splits in a particular patch).
 # 3. Read the data from the products.
 # 4. Create a co-added map from the splits.
@@ -111,6 +111,7 @@ collection = collections.read(client=client, id=COLLECTION)
 # Make sure the whole collection is cached on our machine. This will automatically
 # download any missing files if they are needed.
 collections.cache(client=client, cache=cache, id=COLLECTION)
+
 
 # %% [markdown]
 # If we view that collection, there are a number of patches and products including
@@ -292,6 +293,7 @@ products_in_patch = [
 print(f"Found {len(products_in_patch)} products in patch {PATCH}.")
 print("Products: " + ", ".join(products_in_patch))
 
+
 # %% [markdown]
 # Now that we have the products we want, we can read them and coadd them. To do this, we
 # need to call the `product.read` function for each product, which gets us the programatically-
@@ -431,5 +433,3 @@ for product_id in products_in_patch:
 # Note here that we do not have a `cached` version of this file. But we have it on disk!
 # That's because hippo doesn't know about your own filesystem, just the cache. You'll need
 # to download it back from hippo to get it back into your cache.
-
-# %%

--- a/examples/simpleserve.py
+++ b/examples/simpleserve.py
@@ -13,6 +13,7 @@ view their metadata through the web frontend.
 """
 
 import os
+from subprocess import check_output
 
 import uvicorn
 from testcontainers.minio import MinioContainer
@@ -55,6 +56,9 @@ def containers_to_environment(
         "add_cors": "yes",
         "web": "yes",
         "create_test_user": "yes",
+        "web_jwt_secret": check_output(["openssl", "rand", "-hex", "32"])
+        .decode("utf-8")
+        .strip(),
     }
 
     os.environ.update(settings)

--- a/hippoclient/core.py
+++ b/hippoclient/core.py
@@ -64,7 +64,9 @@ class ClientSettings(BaseSettings):
 
     caches: list[Cache] = []
 
-    model_config = SettingsConfigDict(json_file=("config.json", "~/.hippo.conf"), env_prefix="hippo_")
+    model_config = SettingsConfigDict(
+        json_file=("config.json", "~/.hippo.conf"), env_prefix="hippo_"
+    )
 
     @classmethod
     def settings_customise_sources(

--- a/hipposerve/api/app.py
+++ b/hipposerve/api/app.py
@@ -42,7 +42,7 @@ async def lifespan(app: FastAPI):
                 context=SETTINGS.crypt_context,
             )
 
-        await user.set({users.User.api_key: SETTINGS.TEST_USER_API_KEY})
+        await user.set({users.User.api_key: SETTINGS.test_user_api_key})
         print(
             f"Created test user: {user.name} with API key: {user.api_key}. "
             "You should NOT see this message in production."

--- a/hipposerve/api/app.py
+++ b/hipposerve/api/app.py
@@ -37,12 +37,12 @@ async def lifespan(app: FastAPI):
         except UserNotFound:
             user = await users.create(
                 name="admin",
-                password="TEST_PASSWORD",
+                password=SETTINGS.test_user_password,
                 privileges=list(users.Privilege),
                 context=SETTINGS.crypt_context,
             )
 
-        await user.set({users.User.api_key: "TEST_API_KEY"})
+        await user.set({users.User.api_key: SETTINGS.TEST_USER_API_KEY})
         print(
             f"Created test user: {user.name} with API key: {user.api_key}. "
             "You should NOT see this message in production."

--- a/hipposerve/api/app.py
+++ b/hipposerve/api/app.py
@@ -39,7 +39,7 @@ async def lifespan(app: FastAPI):
                 name="admin",
                 password=SETTINGS.test_user_password,
                 privileges=list(users.Privilege),
-                context=SETTINGS.crypt_context,
+                hasher=SETTINGS.hasher,
             )
 
         await user.set({users.User.api_key: SETTINGS.test_user_api_key})

--- a/hipposerve/api/app.py
+++ b/hipposerve/api/app.py
@@ -35,7 +35,12 @@ async def lifespan(app: FastAPI):
         try:
             user = await users.read(name="admin")
         except UserNotFound:
-            user = await users.create(name="admin", privileges=list(users.Privilege))
+            user = await users.create(
+                name="admin",
+                password="TEST_PASSWORD",
+                privileges=list(users.Privilege),
+                context=SETTINGS.crypt_context,
+            )
 
         await user.set({users.User.api_key: "TEST_API_KEY"})
         print(

--- a/hipposerve/api/models/users.py
+++ b/hipposerve/api/models/users.py
@@ -9,6 +9,7 @@ from hipposerve.service.users import Privilege
 
 class CreateUserRequest(BaseModel):
     privileges: list[Privilege]
+    password: str | None
     # TODO: Compliance
 
 
@@ -23,8 +24,9 @@ class ReadUserResponse(BaseModel):
 
 
 class UpdateUserRequest(BaseModel):
-    privileges: list[Privilege] | None
-    refresh_key: bool
+    privileges: list[Privilege] | None = None
+    refresh_key: bool = False
+    password: str | None = None
 
 
 class UpdateUserResponse(BaseModel):

--- a/hipposerve/api/users.py
+++ b/hipposerve/api/users.py
@@ -15,6 +15,7 @@ from hipposerve.api.models.users import (
     UpdateUserResponse,
 )
 from hipposerve.service import users
+from hipposerve.settings import SETTINGS
 
 users_router = APIRouter(prefix="/users")
 
@@ -41,7 +42,9 @@ async def create_user(
     except users.UserNotFound:
         user = await users.create(
             name=name,
+            password=request.password,
             privileges=request.privileges,
+            hasher=SETTINGS.hasher,
         )
 
     return CreateUserResponse(api_key=user.api_key)
@@ -78,6 +81,8 @@ async def update_user(
         name=name,
         privileges=request.privileges,
         refresh_key=request.refresh_key,
+        password=request.password,
+        hasher=SETTINGS.hasher,
     )
 
     return UpdateUserResponse(api_key=user.api_key if request.refresh_key else None)

--- a/hipposerve/database/__init__.py
+++ b/hipposerve/database/__init__.py
@@ -61,6 +61,7 @@ class ComplianceInformation(BaseModel):
 
 class User(Document):
     name: Indexed(str, unique=True)
+    hashed_password: str
     api_key: str
     privileges: list[Privilege]
 

--- a/hipposerve/service/users.py
+++ b/hipposerve/service/users.py
@@ -17,6 +17,7 @@ PASSWORD_BYTES = 32
 def API_KEY():
     return secrets.token_urlsafe(API_KEY_BYTES)
 
+
 def EMPTY_PASSWORD():
     return secrets.token_urlsafe(PASSWORD_BYTES)
 

--- a/hipposerve/service/users.py
+++ b/hipposerve/service/users.py
@@ -10,7 +10,7 @@ from passlib.context import CryptContext
 from hipposerve.database import Privilege, User
 
 # TODO: Settings
-API_KEY_BYTES = 256
+API_KEY_BYTES = 128
 
 
 def API_KEY():

--- a/hipposerve/settings.py
+++ b/hipposerve/settings.py
@@ -31,12 +31,22 @@ class Settings(BaseSettings):
 
     web: bool = False
     "Serve the web frontend."
+
     web_jwt_secret: str | None = None
     "Secret key for JWT (32 bytes hex)"
     web_jwt_algorithm: str = "HS256"
     "Algorithm for JWT"
     web_jwt_expires: timedelta = timedelta(hours=1)
     "Expiration time for JWT"
+
+    web_allow_github_login: bool = False
+    "Allow login with GitHub"
+    web_github_client_id: str | None = None
+    "GitHub client ID"
+    web_github_client_secret: str | None = None
+    "GitHub client secret"
+    web_github_required_organisation_membership: str | None = None
+    "Required GitHub organisation membership for login, if None any organisation is allowed."
 
 
 SETTINGS = Settings()

--- a/hipposerve/settings.py
+++ b/hipposerve/settings.py
@@ -24,7 +24,10 @@ class Settings(BaseSettings):
     debug: bool = True
 
     create_test_user: bool = False
-    "Create a test user with API key 'TEST_API_KEY' and all privaleges on startup."
+    "Create a test user with API key 'test_user_api_key' and all privaleges on startup."
+    test_user_password: str = "TEST_PASSWORD"
+    "Password for the test user."
+    test_user_api_key: str = "TEST_API_KEY"
 
     web: bool = False
     "Serve the web frontend."
@@ -33,7 +36,7 @@ class Settings(BaseSettings):
     web_jwt_algorithm: str = "HS256"
     "Algorithm for JWT"
     web_jwt_expires: timedelta = timedelta(hours=1)
-    "Expiration time for JWT in seconds"
+    "Expiration time for JWT"
 
 
 SETTINGS = Settings()

--- a/hipposerve/settings.py
+++ b/hipposerve/settings.py
@@ -2,6 +2,9 @@
 Server settings, uses pydantic settings models.
 """
 
+from datetime import timedelta
+
+from passlib.context import CryptContext
 from pydantic_settings import BaseSettings
 
 
@@ -15,12 +18,22 @@ class Settings(BaseSettings):
     title: str
     description: str
 
+    crypt_context: CryptContext = CryptContext("bcrypt")
+
     add_cors: bool = True
     debug: bool = True
-    web: bool = False
 
     create_test_user: bool = False
     "Create a test user with API key 'TEST_API_KEY' and all privaleges on startup."
+
+    web: bool = False
+    "Serve the web frontend."
+    web_jwt_secret: str | None = None
+    "Secret key for JWT (32 bytes hex)"
+    web_jwt_algorithm: str = "HS256"
+    "Algorithm for JWT"
+    web_jwt_expires: timedelta = timedelta(hours=1)
+    "Expiration time for JWT in seconds"
 
 
 SETTINGS = Settings()

--- a/hipposerve/settings.py
+++ b/hipposerve/settings.py
@@ -42,6 +42,8 @@ class Settings(BaseSettings):
 
     web_allow_github_login: bool = False
     "Allow login with GitHub"
+    web_only_allow_github_login: bool = False
+    "Only allow login with GitHub"
     web_github_client_id: str | None = None
     "GitHub client ID"
     web_github_client_secret: str | None = None

--- a/hipposerve/settings.py
+++ b/hipposerve/settings.py
@@ -4,7 +4,8 @@ Server settings, uses pydantic settings models.
 
 from datetime import timedelta
 
-from passlib.context import CryptContext
+from pwdlib import PasswordHash
+from pwdlib.hashers.argon2 import Argon2Hasher
 from pydantic_settings import BaseSettings
 
 
@@ -18,7 +19,7 @@ class Settings(BaseSettings):
     title: str
     description: str
 
-    crypt_context: CryptContext = CryptContext("bcrypt")
+    hasher: PasswordHash = PasswordHash([Argon2Hasher()])
 
     add_cors: bool = True
     debug: bool = True

--- a/hipposerve/web/__init__.py
+++ b/hipposerve/web/__init__.py
@@ -157,7 +157,7 @@ async def login_with_github_for_access_token(
             # TODO: MAKE PASSWORDS OPTIONAL
             password="GitHub",
             privileges=list(user_service.Privilege),
-            context=SETTINGS.crypt_context,
+            hasher=SETTINGS.hasher,
         )
 
     access_token = create_access_token(
@@ -181,7 +181,7 @@ async def login_for_access_token(
         user = await user_service.read_with_password_verification(
             name=form_data.username,
             password=form_data.password,
-            context=SETTINGS.crypt_context,
+            hasher=SETTINGS.hasher,
         )
     except user_service.UserNotFound:
         raise HTTPException(

--- a/hipposerve/web/__init__.py
+++ b/hipposerve/web/__init__.py
@@ -172,6 +172,12 @@ async def login_for_access_token(
     request: Request,
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
 ) -> RedirectResponse:
+    if not SETTINGS.web_only_allow_github_login:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="GitHub login is the only login method enabled",
+        )
+
     try:
         user = await user_service.read_with_password_verification(
             name=form_data.username,
@@ -214,5 +220,10 @@ async def read_user(request: Request, user: LoggedInUser):
 async def login(request: Request):
     return templates.TemplateResponse(
         "login.html",
-        {"request": request, "github_client_id": SETTINGS.web_github_client_id},
+        {
+            "request": request,
+            "github_client_id": SETTINGS.web_github_client_id,
+            "only_allow_github_login": SETTINGS.web_only_allow_github_login,
+            "allow_github_login": SETTINGS.web_allow_github_login,
+        },
     )

--- a/hipposerve/web/__init__.py
+++ b/hipposerve/web/__init__.py
@@ -97,7 +97,7 @@ async def login_with_github_for_access_token(
             "https://github.com/login/oauth/access_token",
             data={
                 "client_id": SETTINGS.web_github_client_id,
-                "client_secret": SETTINGS.web_allow_github_login,
+                "client_secret": SETTINGS.web_github_client_secret,
                 "code": code,
             },
             headers={"Accept": "application/json"},
@@ -217,4 +217,4 @@ async def read_user(request: Request, user: LoggedInUser):
 
 @web_router.get("/login")
 async def login(request: Request):
-    return templates.TemplateResponse("login.html", {"request": request})
+    return templates.TemplateResponse("login.html", {"request": request, "github_client_id": SETTINGS.web_github_client_id})

--- a/hipposerve/web/auth.py
+++ b/hipposerve/web/auth.py
@@ -27,7 +27,7 @@ class OAuth2PasswordBearerWithCookie(OAuth2):
     instead of the `Authorization` header. The key method here is ``__call__``,
     which reads the token from the cookie, given a request object, and returns
     the token as a string.
-    
+
     For more complete documentation see the FastAPI documentation on OAuth2
     authentication schemes: ``https://fastapi.tiangolo.com/reference/security/``.
 

--- a/hipposerve/web/auth.py
+++ b/hipposerve/web/auth.py
@@ -21,6 +21,47 @@ from hipposerve.settings import SETTINGS
 
 
 class OAuth2PasswordBearerWithCookie(OAuth2):
+    """
+    A custom OAuth2 scheme (extremely similar to the built-in FastAPI
+    ``OAuth2PasswordBearer`` scheme) that reads the token from a cookie
+    instead of the `Authorization` header. The key method here is ``__call__``,
+    which reads the token from the cookie, given a request object, and returns
+    the token as a string.
+    
+    For more complete documentation see the FastAPI documentation on OAuth2
+    authentication schemes: ``https://fastapi.tiangolo.com/reference/security/``.
+
+    Parameters
+    ----------
+    tokenUrl : str
+        The URL to obtain the OAuth2 token. This would be the path operation that has
+        ``OAuth2PasswordRequestForm`` as a dependency.
+    scheme_name : str, optional
+        The name of the scheme for OpenAPI docs. Defaults to `None`.
+    scopes : dict, optional
+        The OAuth2 scopes that would be required by the path operations
+        that use this dependency.
+    auto_error : bool, optional
+        By default, if no HTTP Authorization header is provided, required for
+        OAuth2 authentication, it will automatically cancel the request and
+        send the client an error.
+
+        If auto_error is set to False, when the HTTP Authorization cookie
+        is not available, instead of erroring out, the dependency result
+        will be None.
+
+        This is provided for compatibility with other OAuth2 schemes, however
+        in hippo we use two separate dependencies for this purpose.
+
+    Notes
+    -----
+    This should, in theory, enable the 'docs' Web UI to store the token in a cookie
+    and work as expected. However, the current implementation does not fully satisfy
+    this as I believe the password form is expecting to use a header. A potential
+    way around this would be to set both, but that could lead to inconsistencies.
+
+    """
+
     def __init__(
         self,
         tokenUrl: str,

--- a/hipposerve/web/templates/login.html
+++ b/hipposerve/web/templates/login.html
@@ -2,6 +2,7 @@
 {% block content %}
 <div class="container-fluid">
     <h2>Login</h2>
+    {% if not only_allow_github_login %}
     <form action="./token" method="post">
         <div class="mb-3">
             <label for="username" class="form-label">Username</label>
@@ -13,7 +14,9 @@
         </div>
         <button type="submit" class="btn btn-primary">Login</button>
     </form>
-
+    {% endif %}
+    {% if allow_github_login %}
     <p class="mt-3"><a href="https://github.com/login/oauth/authorize?client_id={{ github_client_id }}">Log In with GitHub</a></p>
+    {% endif %}
 </div>
 {% endblock %}

--- a/hipposerve/web/templates/login.html
+++ b/hipposerve/web/templates/login.html
@@ -13,5 +13,7 @@
         </div>
         <button type="submit" class="btn btn-primary">Login</button>
     </form>
+
+    <p class="mt-3"><a href="https://github.com/login/oauth/authorize?client_id={{ github_client_id }}">Log In with GitHub</a></p>
 </div>
 {% endblock %}

--- a/hipposerve/web/templates/login.html
+++ b/hipposerve/web/templates/login.html
@@ -1,0 +1,17 @@
+{% extends "core.html" %}
+{% block content %}
+<div class="container-fluid">
+    <h2>Login</h2>
+    <form action="./token" method="post">
+        <div class="mb-3">
+            <label for="username" class="form-label">Username</label>
+            <input type="text" class="form-control" id="username" name="username" required>
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <input type="password" class="form-control" id="password" name="password" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Login</button>
+    </form>
+</div>
+{% endblock %}

--- a/hipposerve/web/templates/user.html
+++ b/hipposerve/web/templates/user.html
@@ -1,0 +1,7 @@
+{% extends "core.html" %}
+{% block content %}
+<div class="container-fluid">
+    <h2>{{ user.name }}</h2>
+    <p>API Key: {{ user.api_key }}</p>
+</div>
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
     "typer",
     "httpx",
     "astropy",
+    "pyjwt",
+    "passlib","python-multipart","bcrypt==4.0.1"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "httpx",
     "astropy",
     "pyjwt",
-    "passlib","python-multipart","bcrypt==4.0.1"
+    "pwdlib[argon2]",
+    "python-multipart",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_api/conftest.py
+++ b/tests/test_api/conftest.py
@@ -44,7 +44,7 @@ def test_api_user(test_api_client: TestClient):
     TEST_USER_PRIVALEGES = [x.value for x in Privilege]
 
     response = test_api_client.put(
-        f"/users/{TEST_USER_NAME}", json={"privileges": TEST_USER_PRIVALEGES}
+        f"/users/{TEST_USER_NAME}", json={"privileges": TEST_USER_PRIVALEGES, "password": "password"}
     )
 
     assert response.status_code == 200

--- a/tests/test_api/conftest.py
+++ b/tests/test_api/conftest.py
@@ -44,7 +44,8 @@ def test_api_user(test_api_client: TestClient):
     TEST_USER_PRIVALEGES = [x.value for x in Privilege]
 
     response = test_api_client.put(
-        f"/users/{TEST_USER_NAME}", json={"privileges": TEST_USER_PRIVALEGES, "password": "password"}
+        f"/users/{TEST_USER_NAME}",
+        json={"privileges": TEST_USER_PRIVALEGES, "password": "password"},
     )
 
     assert response.status_code == 200

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -19,7 +19,8 @@ def test_create_user_that_exists(test_api_client: TestClient, test_api_user: str
             "privileges": [
                 Privilege.DOWNLOAD_PRODUCT.value,
                 Privilege.LIST_PRODUCT.value,
-            ]
+            ],
+            "password": "password",
         },
     )
 

--- a/tests/test_services/conftest.py
+++ b/tests/test_services/conftest.py
@@ -36,7 +36,12 @@ async def database(database_container):
 async def created_user(database):
     from hipposerve.service import users
 
-    user = await users.create(name="test_user", privileges=list(users.Privilege), password="password", hasher=PasswordHash([Argon2Hasher()]))
+    user = await users.create(
+        name="test_user",
+        privileges=list(users.Privilege),
+        password="password",
+        hasher=PasswordHash([Argon2Hasher()]),
+    )
 
     yield user
 

--- a/tests/test_services/conftest.py
+++ b/tests/test_services/conftest.py
@@ -10,6 +10,8 @@ import pytest_asyncio
 import requests
 from beanie import init_beanie
 from motor.motor_asyncio import AsyncIOMotorClient
+from pwdlib import PasswordHash
+from pwdlib.hashers.argon2 import Argon2Hasher
 
 from hipposerve.database import BEANIE_MODELS
 
@@ -34,7 +36,7 @@ async def database(database_container):
 async def created_user(database):
     from hipposerve.service import users
 
-    user = await users.create(name="test_user", privileges=list(users.Privilege))
+    user = await users.create(name="test_user", privileges=list(users.Privilege), password="password", hasher=PasswordHash([Argon2Hasher()]))
 
     yield user
 

--- a/tests/test_services/test_product_service.py
+++ b/tests/test_services/test_product_service.py
@@ -9,10 +9,10 @@ import pytest
 import requests
 from beanie import PydanticObjectId
 from beanie.odm.fields import Link
-
-from hipposerve.service import product, users, versioning
 from pwdlib import PasswordHash
 from pwdlib.hashers.argon2 import Argon2Hasher
+
+from hipposerve.service import product, users, versioning
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -114,7 +114,10 @@ async def test_add_to_collection(created_collection, created_full_product, datab
 @pytest.mark.asyncio(loop_scope="session")
 async def test_update_metadata(created_full_product, database, storage):
     new_user = await users.create(
-        name="new_user", privileges=[users.Privilege.LIST_PRODUCT], password="password", hasher=PasswordHash([Argon2Hasher()])
+        name="new_user",
+        privileges=[users.Privilege.LIST_PRODUCT],
+        password="password",
+        hasher=PasswordHash([Argon2Hasher()]),
     )
 
     existing_version = created_full_product.version

--- a/tests/test_services/test_product_service.py
+++ b/tests/test_services/test_product_service.py
@@ -11,6 +11,8 @@ from beanie import PydanticObjectId
 from beanie.odm.fields import Link
 
 from hipposerve.service import product, users, versioning
+from pwdlib import PasswordHash
+from pwdlib.hashers.argon2 import Argon2Hasher
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -112,7 +114,7 @@ async def test_add_to_collection(created_collection, created_full_product, datab
 @pytest.mark.asyncio(loop_scope="session")
 async def test_update_metadata(created_full_product, database, storage):
     new_user = await users.create(
-        name="new_user", privileges=[users.Privilege.LIST_PRODUCT]
+        name="new_user", privileges=[users.Privilege.LIST_PRODUCT], password="password", hasher=PasswordHash([Argon2Hasher()])
     )
 
     existing_version = created_full_product.version

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -3,11 +3,10 @@ Tests the functions in the user service.
 """
 
 import pytest
-
-from hipposerve.service import users
-
 from pwdlib import PasswordHash
 from pwdlib.hashers.argon2 import Argon2Hasher
+
+from hipposerve.service import users
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -6,6 +6,9 @@ import pytest
 
 from hipposerve.service import users
 
+from pwdlib import PasswordHash
+from pwdlib.hashers.argon2 import Argon2Hasher
+
 
 @pytest.mark.asyncio(loop_scope="session")
 async def test_read_user(created_user):
@@ -21,6 +24,8 @@ async def test_update_user(created_user):
     this_user = await users.update(
         name=created_user.name,
         privileges=[users.Privilege.DOWNLOAD_PRODUCT],
+        password=None,
+        hasher=PasswordHash([Argon2Hasher()]),
         refresh_key=True,
     )
 
@@ -30,6 +35,8 @@ async def test_update_user(created_user):
     this_user = await users.update(
         name=created_user.name,
         privileges=[users.Privilege.LIST_PRODUCT],
+        password=None,
+        hasher=PasswordHash([Argon2Hasher()]),
         refresh_key=False,
     )
 


### PR DESCRIPTION
Tests don't pass yet but this is the implementation of authentication for the web-based frontend. API access is done with an API key (which itself is accessible within the web frontend).

We use cookies instead of the typical Auth header to ensure we don't need to intercept HTTP requests (and can hence have a static frontend if we want).

@zonca would you be able to take a look at my implementation (particularly auth.py)?