### PR TITLE
Add origin check at JWT

### DIFF
--- a/hipposerve/api/app.py
+++ b/hipposerve/api/app.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 
 from beanie import init_beanie
 from fastapi import FastAPI
+from loguru import logger
 from motor.motor_asyncio import AsyncIOMotorClient
 from starlette.middleware.cors import CORSMiddleware
 
@@ -43,14 +44,16 @@ async def lifespan(app: FastAPI):
             )
 
         await user.set({users.User.api_key: SETTINGS.test_user_api_key})
-        print(
-            f"Created test user: {user.name} with API key: {user.api_key}. "
-            "You should NOT see this message in production."
+        logger.warning(
+            "Created test user: {} with API key: {}, "
+            "you should NOT see this message in production",
+            user.name,
+            user.api_key,
         )
 
-    print("Startup complete")
+    logger.info("Startup complete")
     yield
-    print("Shutdown complete")
+    logger.info("Shutdown complete")
 
 
 app = FastAPI(
@@ -69,10 +72,16 @@ app.include_router(relationship_router)
 if SETTINGS.web:  # pragma: no cover
     from hipposerve.web import static_files, web_router
 
+    logger.info("Web interface enabled, serving it from {}", web_router.prefix)
+
     app.include_router(web_router)
     app.mount(**static_files)
 
 if SETTINGS.add_cors:
+    logger.warning(
+        "Completely open CORS policy enabled, designed for testing and development"
+    )
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],

--- a/hipposerve/api/auth.py
+++ b/hipposerve/api/auth.py
@@ -7,6 +7,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, Security, status
 from fastapi.security import APIKeyHeader
+from loguru import logger
 
 from hipposerve.service import users
 
@@ -15,7 +16,9 @@ api_key_header = APIKeyHeader(name="X-API-Key")
 
 async def get_user(api_key_header: str = Security(api_key_header)) -> users.User:
     try:
-        return await users.user_from_api_key(api_key_header)
+        user = await users.user_from_api_key(api_key_header)
+        logger.info(f"Authenticated user using API key: {user.name}")
+        return user
     except users.UserNotFound:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/hipposerve/api/users.py
+++ b/hipposerve/api/users.py
@@ -5,6 +5,7 @@ TODO: Authentication.
 """
 
 from fastapi import APIRouter, HTTPException, status
+from loguru import logger
 
 from hipposerve.api.auth import UserDependency, check_user_for_privilege
 from hipposerve.api.models.users import (
@@ -31,6 +32,8 @@ async def create_user(
     Create a new user.
     """
 
+    logger.info("Request to create user: {} from {}", name, calling_user.name)
+
     await check_user_for_privilege(calling_user, users.Privilege.CREATE_USER)
 
     try:
@@ -47,6 +50,8 @@ async def create_user(
             hasher=SETTINGS.hasher,
         )
 
+    logger.info("User {} created for {}", user.name, calling_user.name)
+
     return CreateUserResponse(api_key=user.api_key)
 
 
@@ -56,10 +61,14 @@ async def read_user(name: str, calling_user: UserDependency) -> ReadUserResponse
     Read a user's details, but not their API key.
     """
 
+    logger.info("Request to read user: {} from {}", name, calling_user.name)
+
     if name != calling_user.name:
         await check_user_for_privilege(calling_user, users.Privilege.READ_USER)
 
     user = await users.read(name=name)
+
+    logger.info("User {} read by {}", name, calling_user.name)
 
     return ReadUserResponse(
         name=user.name,
@@ -75,6 +84,8 @@ async def update_user(
     Update a user's details. At present, only admins can update users.
     """
 
+    logger.info("Request to update user: {} from {}", name, calling_user.name)
+
     await check_user_for_privilege(calling_user, users.Privilege.UPDATE_USER)
 
     user = await users.update(
@@ -83,6 +94,14 @@ async def update_user(
         refresh_key=request.refresh_key,
         password=request.password,
         hasher=SETTINGS.hasher,
+    )
+
+    logger.info(
+        "User {} updated by {} with new API key"
+        if request.refresh_key
+        else "User {} updated by {}",
+        name,
+        calling_user.name,
     )
 
     return UpdateUserResponse(api_key=user.api_key if request.refresh_key else None)
@@ -94,8 +113,12 @@ async def delete_user(name: str, calling_user: UserDependency) -> None:
     Delete a user.
     """
 
+    logger.info("Request to delete user: {} from {}", name, calling_user.name)
+
     await check_user_for_privilege(calling_user, users.Privilege.DELETE_USER)
 
     await users.delete(name=name)
+
+    logger.info("User {} deleted by {}", name, calling_user.name)
 
     return

--- a/hipposerve/settings.py
+++ b/hipposerve/settings.py
@@ -29,6 +29,7 @@ class Settings(BaseSettings):
     test_user_password: str = "TEST_PASSWORD"
     "Password for the test user."
     test_user_api_key: str = "TEST_API_KEY"
+    "API key for the test user."
 
     web: bool = False
     "Serve the web frontend."
@@ -39,6 +40,8 @@ class Settings(BaseSettings):
     "Algorithm for JWT"
     web_jwt_expires: timedelta = timedelta(hours=1)
     "Expiration time for JWT"
+    web_jwt_check_origin: bool = True
+    "Check the origin header against the HTTP request for cookie JWT tokens. Heps depend against CSRF attacks."
 
     web_allow_github_login: bool = False
     "Allow login with GitHub"

--- a/hipposerve/web/__init__.py
+++ b/hipposerve/web/__init__.py
@@ -281,8 +281,6 @@ async def login_for_access_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    print(request.headers)
-
     access_token = create_access_token(
         user=user,
         expires_delta=SETTINGS.web_jwt_expires,

--- a/hipposerve/web/__init__.py
+++ b/hipposerve/web/__init__.py
@@ -244,7 +244,9 @@ async def login_with_github_for_access_token(
         )
 
     access_token = create_access_token(
-        user=user, expires_delta=SETTINGS.web_jwt_expires
+        user=user,
+        expires_delta=SETTINGS.web_jwt_expires,
+        origin=request.headers.get("Origin"),
     )
 
     new_response = RedirectResponse(
@@ -260,7 +262,7 @@ async def login_for_access_token(
     request: Request,
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
 ) -> RedirectResponse:
-    if not SETTINGS.web_only_allow_github_login:
+    if SETTINGS.web_only_allow_github_login:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="GitHub login is the only login method enabled",
@@ -279,8 +281,12 @@ async def login_for_access_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    print(request.headers)
+
     access_token = create_access_token(
-        user=user, expires_delta=SETTINGS.web_jwt_expires
+        user=user,
+        expires_delta=SETTINGS.web_jwt_expires,
+        origin=request.headers.get("Origin"),
     )
 
     new_response = RedirectResponse(

--- a/hipposerve/web/auth.py
+++ b/hipposerve/web/auth.py
@@ -124,7 +124,6 @@ async def get_current_user(
         if sub is None:
             raise credentials_exception
         token_data = WebTokenData.decode(sub)
-        print(token_data)
     except jwt.PyJWTError:
         raise credentials_exception
     except ValueError:
@@ -170,7 +169,6 @@ def create_access_token(
     encoded_jwt = jwt.encode(
         to_encode, SETTINGS.web_jwt_secret, algorithm=SETTINGS.web_jwt_algorithm
     )
-    print(to_encode)
     return f"Bearer {encoded_jwt}"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pyjwt",
     "pwdlib[argon2]",
     "python-multipart",
+    "loguru",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_api/conftest.py
+++ b/tests/test_api/conftest.py
@@ -41,11 +41,11 @@ def test_api_client(test_api_server):
 @pytest.fixture(scope="module")
 def test_api_user(test_api_client: TestClient):
     TEST_USER_NAME = "default_user"
-    TEST_USER_PRIVALEGES = [x.value for x in Privilege]
+    TEST_USER_PRIVILEGES = [x.value for x in Privilege]
 
     response = test_api_client.put(
         f"/users/{TEST_USER_NAME}",
-        json={"privileges": TEST_USER_PRIVALEGES, "password": "password"},
+        json={"privileges": TEST_USER_PRIVILEGES, "password": "password"},
     )
 
     assert response.status_code == 200


### PR DESCRIPTION
Adds an additional origin check and stores the origin in the JWT. Fixes #15.

This should help prevent CSRF attacks, though the web frontend primarily uses GET requests anyway (for now at least, once we start adding update functionality we will need to do some POSTing).