### PR TITLE
Render source description in product sources table

### DIFF
--- a/hipposerve/web/templates/product.html
+++ b/hipposerve/web/templates/product.html
@@ -21,6 +21,7 @@
             <thead>
                 <tr class="table-secondary">
                     <th>Link</th>
+                    <th>Description</th>
                     <th>Size</th>
                 </tr>
             </thead>
@@ -28,6 +29,7 @@
                 {% for source in sources %}
                 <tr>
                     <td><a href='{{ source.url }}'>{{ source.name }}</a></td>
+                    <td>{{ source.description }}</td>
                     <td class="text-nowrap">{{ source.size }} B</td>
                 </tr>
                 {% endfor %}


### PR DESCRIPTION
Simple addition of the source description to the product sources table.
![image](https://github.com/user-attachments/assets/6aabdb74-6cf0-4a2c-b327-83874e754439)
